### PR TITLE
JSON Errors Messages

### DIFF
--- a/tessitura/__init__.py
+++ b/tessitura/__init__.py
@@ -30,20 +30,20 @@ def rest_call(endpoint, credentials, request_type, method, *args, **kwargs):
         
         timeout = {
             "error": 500,
-            "message": "Error connecting to Tessitura",
+            "message": "Time Out Error connecting to Tessitura",
             "e": e
         }
 
         return timeout
     
-    j = r.json()
-
     if r.status_code != 200:
         
         j = {
             "error": r.status_code,
-            "message": j[0]['Description']
-        }
+            "message": r.reason
+        }     
+    else:
+        j = r.json()
     
     return j
 


### PR DESCRIPTION
Micah,

Here is a pull request that I've done straight from the github site.  Do a quick test when a timeout error condition exists,  Also test the case where you have a non-200 status code.  You should now get json with an error message.

--Tom

Updated Time Out Error message so that error message makes it clear that this is a Time Out Error
Fixes non- 200 status errors so that it does not error out and actual message and actualy returns error in Json